### PR TITLE
fix bind_blob memory leak

### DIFF
--- a/src/main/native/Sqlite3C.cc
+++ b/src/main/native/Sqlite3C.cc
@@ -103,9 +103,9 @@ JNIEXPORT jint JNICALL Java_org_srhea_scalaqlite_Sqlite3C_bind_1blob
 {
     jint len = env->GetArrayLength(jvalue);
     jboolean iscopy;
-    const char *cvalue = (const char *) env->GetByteArrayElements(jvalue, &iscopy);
+    jbyte *cvalue = (jbyte *) env->GetByteArrayElements(jvalue, &iscopy);
     int r = sqlite3_bind_blob((sqlite3_stmt*) jstmt, jindex, cvalue, len, SQLITE_TRANSIENT);
-    env->ReleaseByteArrayElements(jvalue, 0, len);
+    env->ReleaseByteArrayElements(jvalue, cvalue, 0);
     return r;
 }
 


### PR DESCRIPTION
In the bind_blob method, the arguments that were passed into
ReleaseByteArrayElements made absolutely no sense, but caused neither a
compiler error nor a runtime error. They did, however, cause a memory
leak since they native byte arrays that were being heap allocated were
never freed.
