### PR TITLE
prepare: throw exception instead of assertion

### DIFF
--- a/src/main/scala/SqliteDb.scala
+++ b/src/main/scala/SqliteDb.scala
@@ -122,7 +122,8 @@ class SqliteDb(path: String) {
     def prepare[R](sql: String)(f: SqliteStatement => R): R = {
         assert(db(0) != 0, "db is closed")
         val stmtPointer = Array(0L)
-        Sqlite3C.prepare_v2(db(0), sql, stmtPointer) ensuring (_ == Sqlite3C.OK, errmsg)
+        if (Sqlite3C.prepare_v2(db(0), sql, stmtPointer) != Sqlite3C.OK)
+          throw new Exception(errmsg)
         val stmt = new SqliteStatement(this, stmtPointer)
         try f(stmt) finally stmt.close
     }


### PR DESCRIPTION
There are cases where you may want to be able to recover from a failure
to prepare a statement. As an example, the prepare may fail because it
uses a foreign data table that Sqlite is currently unaware of. By
throwing an exception, it is possible to recover from the failure,
update the db and retry.

Reviewed-by: srhea@meraki.com
