### PR TITLE
add sqlite3_changes native function

### DIFF
--- a/src/main/java/Sqlite3C.java
+++ b/src/main/java/Sqlite3C.java
@@ -44,6 +44,7 @@ public class Sqlite3C {
     native static public double column_double(long stmt, int n);
     native static public byte[] column_blob(long stmt, int n);
     native static public String errmsg(long db);
+    native static public int sqlite3_changes(long db);
 
     static {
         System.loadLibrary("scalaqlite");

--- a/src/main/native/Sqlite3C.cc
+++ b/src/main/native/Sqlite3C.cc
@@ -167,3 +167,9 @@ Java_org_srhea_scalaqlite_Sqlite3C_errmsg(JNIEnv *env, jclass cls, jlong jdb)
     sqlite3 *db = (sqlite3*) jdb;
     return env->NewStringUTF(sqlite3_errmsg(db));
 }
+
+JNIEXPORT jint JNICALL
+Java_org_srhea_scalaqlite_Sqlite3C_sqlite3_1changes(JNIEnv *, jclass, jlong jdb)
+{
+    return sqlite3_changes((sqlite3*) jdb);
+}

--- a/src/main/scala/SqliteDb.scala
+++ b/src/main/scala/SqliteDb.scala
@@ -140,4 +140,5 @@ class SqliteDb(path: String) {
         Sqlite3C.enable_load_extension(db(0), if (on) 1 else 0)
     }
     def errmsg: String = if (db(0) == 0) "db not open" else Sqlite3C.errmsg(db(0))
+    def changeCount: Int = Sqlite3C.sqlite3_changes(db(0))
 }


### PR DESCRIPTION
This function can be used to get the number of rows inserted or updated
by the last executed statement.
