### PR TITLE
SqliteDb.scala: remove SqlInt type (breaks legacy compatibility)

### DIFF
--- a/src/main/scala/SqliteDb.scala
+++ b/src/main/scala/SqliteDb.scala
@@ -20,13 +20,6 @@ case class SqlNull() extends SqlValue {
   override def isNull = true
   override def bindValue(stmt: Long, col: Int) = Sqlite3C.bind_null(stmt, col)
 }
-case class SqlInt(i: Int) extends SqlValue {
-  override def toString = i.toString
-  override def toDouble = i
-  override def toInt = i
-  override def toLong = i
-  override def bindValue(stmt: Long, col: Int) = Sqlite3C.bind_int64(stmt, col, i.toLong)
-}
 case class SqlLong(i: Long) extends SqlValue {
   override def toString = i.toString
   override def toDouble = i
@@ -79,12 +72,7 @@ class SqliteResultIterator(db: SqliteDb, private val stmt: Long)
             case Sqlite3C.ROW =>
                 (0 until Sqlite3C.column_count(stmt)).map { i =>
                     Sqlite3C.column_type(stmt, i) match {
-                        case Sqlite3C.INTEGER =>
-                          val j = Sqlite3C.column_int64(stmt, i)
-                          if (j <= Integer.MAX_VALUE && j >= Integer.MIN_VALUE)
-                            SqlInt(j.toInt)
-                          else
-                            SqlLong(j)
+                        case Sqlite3C.INTEGER => SqlLong(Sqlite3C.column_int64(stmt, i))
                         case Sqlite3C.FLOAT => SqlDouble(Sqlite3C.column_double(stmt, i))
                         case Sqlite3C.TEXT => SqlText(new String(Sqlite3C.column_blob(stmt, i)))
                         case Sqlite3C.BLOB => SqlBlob(Sqlite3C.column_blob(stmt, i))

--- a/src/test/scala/SqliteDbSpec.scala
+++ b/src/test/scala/SqliteDbSpec.scala
@@ -17,15 +17,15 @@ class SqliteDbSpec extends FlatSpec with ShouldMatchers {
     "INSERT" should "add rows to the table" in {
         db.execute("INSERT INTO foo (i, f, t) VALUES (1, 2.0, 'foo');")
         db.execute("INSERT INTO foo (i, f, t) VALUES (3, NULL, 'bar');")
-        db.foreachRow("SELECT count(*) FROM foo;") { row => row(0) should equal (SqlInt(2)) }
+        db.foreachRow("SELECT count(*) FROM foo;") { row => row(0) should equal (SqlLong(2)) }
     }
 
     "a prepared statement INSERT" should "add rows to the table" in {
         db.prepare("INSERT INTO foo (i, f, t) VALUES (?, ?, ?);") { stmt =>
-            stmt.execute(SqlInt(5), SqlDouble(10.0), SqlText("foobar"))
-            stmt.execute(SqlInt(5), SqlDouble(11.0), SqlText("notfoobar"))
+            stmt.execute(SqlLong(5), SqlDouble(10.0), SqlText("foobar"))
+            stmt.execute(SqlLong(5), SqlDouble(11.0), SqlText("notfoobar"))
         }
-        db.foreachRow("SELECT count(*) FROM foo WHERE i > 4") { row => row(0) should equal (SqlInt(2)) }
+        db.foreachRow("SELECT count(*) FROM foo WHERE i > 4") { row => row(0) should equal (SqlLong(2)) }
     }
 
     "SELECT *" should "output all the rows" in {
@@ -65,8 +65,8 @@ class SqliteDbSpec extends FlatSpec with ShouldMatchers {
     }
 
     "values that fit in an int" should "be returned as an int" in {
-      db.foreachRow("SELECT " + Integer.MIN_VALUE + ";") { row => row(0).isInstanceOf[SqlInt] should equal (true) }
-      db.foreachRow("SELECT " + Integer.MAX_VALUE + ";") { row => row(0).isInstanceOf[SqlInt] should equal (true) }
+      db.foreachRow("SELECT " + Integer.MIN_VALUE + ";") { row => row(0).isInstanceOf[SqlLong] should equal (true) }
+      db.foreachRow("SELECT " + Integer.MAX_VALUE + ";") { row => row(0).isInstanceOf[SqlLong] should equal (true) }
     }
 
     "values that don't fit in an int" should "throw an exception on toInt" in {
@@ -82,9 +82,9 @@ class SqliteDbSpec extends FlatSpec with ShouldMatchers {
       db.execute("INSERT INTO bar (i, d) VALUES (1, 4.0);")
       db.execute("INSERT INTO bar (i, d) VALUES (2, 5.0);")
       db.prepare("SELECT * FROM bar WHERE i = ?;") { stmt =>
-        stmt.query(SqlInt(1)) { i => i.hasNext should equal(true)
+        stmt.query(SqlLong(1)) { i => i.hasNext should equal(true)
           i.next()(1).toDouble should equal (2.0) }
-        stmt.query(SqlInt(2)) { i => i.hasNext should equal(true)
+        stmt.query(SqlLong(2)) { i => i.hasNext should equal(true)
           i.next()(1).toDouble should equal (5.0) }
       }
     }


### PR DESCRIPTION
The SqlInt type was unnecessary and made it difficult to do pattern
matching on the results of queries because you had to handle both
SqlLong and SqlInt. For example, before you would have had to write
code like:

db.foreachRow("SELECT x FROM foo") {
  case Seq(SqlInt(x)) => println(x)
  case Seq(SqlLong(x)) => println(x)
}

to take advantage of case class extractors.

Now you can do:
db.foreahRow("SELECT \* FROM foo") { case Seq(SqlLong(x)) => println(x) }

This change breaks compatibility with an legacy code that uses SqlInt.
