### PR TITLE
Change SqlText bind method

### DIFF
--- a/src/main/java/Sqlite3C.java
+++ b/src/main/java/Sqlite3C.java
@@ -34,7 +34,7 @@ public class Sqlite3C {
     native static public int bind_null(long stmt, int index);
     native static public int bind_int64(long stmt, int index, long value);
     native static public int bind_double(long stmt, int index, double value);
-    native static public int bind_text(long stmt, int index, String value);
+    native static public int bind_text(long stmt, int index, byte[] value);
     native static public int bind_blob(long stmt, int index, byte[] value);
     native static public int step(long stmt);
     native static public int finalize(long stmt);

--- a/src/main/native/Sqlite3C.cc
+++ b/src/main/native/Sqlite3C.cc
@@ -88,13 +88,13 @@ JNIEXPORT jint JNICALL Java_org_srhea_scalaqlite_Sqlite3C_bind_1double
 }
 
 JNIEXPORT jint JNICALL Java_org_srhea_scalaqlite_Sqlite3C_bind_1text
-  (JNIEnv *env, jclass cls, jlong jstmt, jint jindex, jstring jvalue)
+  (JNIEnv *env, jclass cls, jlong jstmt, jint jindex, jbyteArray jvalue)
 {
+    jint len = env->GetArrayLength(jvalue);
     jboolean iscopy;
-    jint len = env->GetStringLength(jvalue);
-    const char *cvalue = env->GetStringUTFChars(jvalue, &iscopy);
-    int r = sqlite3_bind_text((sqlite3_stmt*) jstmt, jindex, cvalue, len, SQLITE_TRANSIENT);
-    env->ReleaseStringUTFChars(jvalue, cvalue);
+    jbyte *cvalue = (jbyte *) env->GetByteArrayElements(jvalue, &iscopy);
+    int r = sqlite3_bind_text((sqlite3_stmt*) jstmt, jindex, (const char *) cvalue, len, SQLITE_TRANSIENT);
+    env->ReleaseByteArrayElements(jvalue, cvalue, 0);
     return r;
 }
 

--- a/src/main/scala/SqliteDb.scala
+++ b/src/main/scala/SqliteDb.scala
@@ -49,7 +49,7 @@ case class SqlBlob(bytes: Seq[Byte]) extends SqlValue {
 }
 case class SqlText(s: String) extends SqlValue {
     override def toString = s
-    override def bindValue(stmt: Long, col: Int) = Sqlite3C.bind_text(stmt, col, s)
+    override def bindValue(stmt: Long, col: Int) = Sqlite3C.bind_text(stmt, col, s.getBytes("UTF-8"))
 }
 
 class SqliteStatement(db: SqliteDb, private val stmt: Array[Long]) {

--- a/src/test/scala/SqliteDbSpec.scala
+++ b/src/test/scala/SqliteDbSpec.scala
@@ -75,6 +75,16 @@ class SqliteDbSpec extends FlatSpec with ShouldMatchers {
       }
     }
 
+    "Non-ascii characters" should "be bound correctly" in {
+      val str = "百"
+      db.execute("CREATE TABLE non_ascii_test (str TEXT)")
+      db.execute("INSERT INTO non_ascii_test VALUES (?1)", SqlText(str))
+      db.foreachRow("SELECT str FROM non_ascii_test") { case Seq(SqlText(s)) =>
+        s should equal(str)
+        s.getBytes should equal(Array[Byte](-25, -103, -66))
+      }
+    }
+
     "Prepared statements" should "properly reset themselves" in {
       db.execute("CREATE TABLE bar (i INTEGER, d DOUBLE);")
       db.execute("INSERT INTO bar (i, d) VALUES (1, 2.0);")


### PR DESCRIPTION
We discovered recently that Scalaqlite didn't correctly bind UTF-8
strings that contained non-ascii characters, e.g. Chinese characters.
One fix would be to change the line in
Java_org_srhea_scalaqlite_Sqlite3C_bind_1text from

jint len = env->GetStringLength(jvalue);

to

jint len = env->GetStringUTFLength(jvalue);

but, from the documenation, getStringUTFLength returns the length in
bytes of the modified UTF-8 representation of a string. It feels cleaner
to just work directly with the byte array, hence this change.

This is about 5% slower than using java character arrays, but those are
unfortunately serialized as modified-utf8 arrays, so this is safer.
